### PR TITLE
Improve candidates

### DIFF
--- a/dataprocessing/csv_db.py
+++ b/dataprocessing/csv_db.py
@@ -87,6 +87,7 @@ schemata = {
 		{'field': 'firstname', 'dtype': str, 'type': 'TEXT', 'constraints': ''},
 		{'field': 'prefix', 'dtype': str, 'type': 'TEXT', 'constraints': ''},
 		{'field': 'familyname', 'dtype': str, 'type': 'TEXT', 'constraints': ''},
+		{'field': 'name_normalized', 'dtype': str, 'type': 'TEXT', 'constraints': ''},
 		{'field': 'role', 'dtype': str, 'type': 'TEXT', 'constraints': ''},
 		{'field': 'author_ppn', 'dtype': str, 'type': 'TEXT', 'constraints': ''}],
 	'publication_datasplits': [

--- a/dataprocessing/indices.py
+++ b/dataprocessing/indices.py
@@ -1,0 +1,31 @@
+import sqlite3
+import csv_db
+
+def create_index(table, columns,db = '../data/demosaurus.sqlite'):
+	"""General function for creating indices on specified table for specified columns
+	"""
+	statement = "CREATE INDEX IF NOT EXISTS %s" % '_'.join([table]+columns)
+	statement += "\nON %s(%s)" % (table, ','.join(columns))
+
+	with sqlite3.connect(db) as con:
+		c = con.cursor()
+		c.execute(statement)	
+
+def set_fts5(db='../data/demosaurus.sqlite'):
+	with sqlite3.connect(db) as con:
+		# Create virtual author table for high-performance text search (obtain candidates)
+		con.execute("DROP TABLE IF EXISTS `author_fts5`;")
+		con.execute("CREATE VIRTUAL TABLE author_fts5 USING FTS5(author_ppn, searchkey, name, name_normalized, familyname);")
+		con.execute("INSERT INTO author_fts5 SELECT author_ppn, searchkey, name, name_normalized, familyname FROM author_name_options ;")
+	return
+
+def create_indices(db = '../data/demosaurus.sqlite'):
+
+	for table_name in csv_db.schemata.keys():
+		if 'publication_' in table_name:
+			create_index(table_name, ['publication_ppn'], db=db)  # Common entry: look up by publication
+		if 'author_' in table_name:
+			create_index(table_name, ['author_ppn'], db=db)  # Common entry: look up by author
+	create_index('publication_contributors', ['author_ppn'],
+				 db=db)  # Common entry for authorship: look up publications by author
+	set_fts5(db=db) # To speed-up retrieval of candidates

--- a/dataprocessing/preprocessing.py
+++ b/dataprocessing/preprocessing.py
@@ -6,6 +6,7 @@ import nltk
 from collections import Counter
 import pickle
 import csv_db
+from demosauruswebapp.demosaurus.link_thesaurus import normalize_name
 
 """For text processing, obtain stop word list from file and initialize tokenizer"""
 with open('dataprocessing/stopwordsDutch.txt','r') as f:
@@ -39,6 +40,10 @@ def CBK_genres_to_identifiers(CBK_genres):
     else:
         CBK_genres.rename(columns={'term':'term_identifier'})
     return CBK_genres[['publication_ppn','term_identifier','rank']]
+
+def normalize_author_names(publication_contributors):
+    publication_contributors['name_normalized'] = publication_contributors.apply(lambda row: normalize_name(' '.join([i for i in [row.firstname, row.prefix, row.familyname] if type(i)==str])), axis = 1)
+    return publication_contributors
 
 def normalize_publishers(basicinfo, postfix):
     # map publishers to canonical form

--- a/dataprocessing/process-data.py
+++ b/dataprocessing/process-data.py
@@ -4,7 +4,8 @@ import read_pica
 import preprocessing
 import read_rdf
 import csv_db
-import views_and_indices
+import views
+import indices
 import os
 import numpy as np
 
@@ -40,6 +41,7 @@ def create_datasplits(set_name, dataset_id, heldout_file=''):
 def apply_preprocessing(dfs, postfix=''):
     # dfs['publication_basicinfo'] = preprocessing.normalize_publishers(dfs['publication_basicinfo'], postfix)
     dfs['publication_CBK_genre'] = preprocessing.CBK_genres_to_identifiers(dfs['publication_CBK_genre'])
+    dfs['publication_contributors'] = preprocessing.normalize_author_names(dfs['publication_contributors'] )
     return dfs
 
 
@@ -93,10 +95,9 @@ if __name__ == '__main__':
     #                  heldout_file = 'data/NBD-pilotdata/KB_validatieset_def.csv')
 
     # Obtain information from CSVs and write to database
-    # for table in csv_db.schemata.keys():
-    #    if table != 'author_name_options': continue
-    #    csv_db.fill_table(table,db='data/demosaurus_NBD.sqlite', overwrite=True, postfix = '_NBD')
+    for table in csv_db.schemata.keys():
+        csv_db.fill_table(table,db='data/demosaurus_NBD.sqlite', overwrite=True, postfix = '_NBD')
 
     # Build indices (+FTS5) and views for regular entries
-    # views_and_indices.create_views(db='data/demosaurus_NBD.sqlite')
-    # views_and_indices.create_indices(db='data/demosaurus_NBD.sqlite')
+    # views.create_views(db='data/demosaurus_NBD.sqlite')
+    # indices.create_indices(db='data/demosaurus_NBD.sqlite')

--- a/dataprocessing/views.py
+++ b/dataprocessing/views.py
@@ -1,5 +1,4 @@
 import sqlite3
-import csv_db
 
 def train_test_views(dataset=''):
 	"""Create database views for train and test set of authorship_ggc table
@@ -16,25 +15,7 @@ def train_test_views(dataset=''):
 		statements[view_name] = statement
 	return statements
 
-def create_index(table, columns,db = '../data/demosaurus.sqlite'):
-	"""General function for creating indices on specified table for specified columns
-	"""
-	statement = "CREATE INDEX IF NOT EXISTS %s" % '_'.join([table]+columns)
-	statement += "\nON %s(%s)" % (table, ','.join(columns))
-
-	with sqlite3.connect(db) as con:
-		c = con.cursor()
-		c.execute(statement)	
-
-def set_fts5(db='../data/demosaurus.sqlite'):
-	with sqlite3.connect(db) as con:
-		# Create virtual author table for high-performance text search (obtain candidates)
-		con.execute("DROP TABLE IF EXISTS `author_fts5`;")
-		con.execute("CREATE VIRTUAL TABLE author_fts5 USING FTS5(author_ppn, searchkey, name, name_normalized, familyname);")
-		con.execute("INSERT INTO author_fts5 SELECT author_ppn, searchkey, name, name_normalized, familyname FROM author_name_options ;")
-	return
-
-def author_aggregated_query():
+def author_aggregated_query(ignore = []):
 	feature_specs = {'CBK_genre':{},
 					 'NUGI_genre':{},
 					 'NUR_rubriek':{},
@@ -45,10 +26,12 @@ def author_aggregated_query():
 					 'jaar_van_uitgave': {'table_name':'publication_basicinfo', 'feature_column': 'jaar_van_uitgave'},
 					 'role':{'table_name':'publication_contributors', 'feature_column':'role'}
 					 }
+	for feaure in ignore:
+		del feature_specs[feaure]
 	query = f"""WITH publication_subset AS(
 			SELECT t0.publication_ppn, t0.author_ppn
 			FROM publication_contributors_train_NBD t0
-			WHERE t0.author_ppn	IS NOT NULL)"""
+			WHERE t0.author_ppn IS NOT NULL)"""
 	for i, (feature_name, specs) in enumerate(feature_specs.items()):
 		if i>0: query += "\nUNION"
 		table_name = specs['table_name'] if 'table_name' in specs else 'publication_'+feature_name
@@ -82,13 +65,3 @@ def create_views(db = '../data/demosaurus.sqlite'):
 			print(view_name, statement)
 			c.execute(statement)
 
-def create_indices(db = '../data/demosaurus.sqlite'):
-
-	for table_name in csv_db.schemata.keys():
-		if 'publication_' in table_name:
-			create_index(table_name, ['publication_ppn'], db=db)  # Common entry: look up by publication
-		if 'author_' in table_name:
-			create_index(table_name, ['author_ppn'], db=db)  # Common entry: look up by author
-	create_index('publication_contributors', ['author_ppn'],
-				 db=db)  # Common entry for authorship: look up publications by author
-	set_fts5(db=db) # To speed-up retrieval of candidates

--- a/dataprocessing/views_and_indices.py
+++ b/dataprocessing/views_and_indices.py
@@ -38,20 +38,13 @@ def author_aggregated_query():
 	feature_specs = {'CBK_genre':{},
 					 'NUGI_genre':{},
 					 'NUR_rubriek':{},
-					 'brinkman':{'suffix':'_zaak',
+					 'brinkman_zaak':{'table_name':'publication_brinkman',
 								 'specifications':[('thesaurus_brinkmantrefwoorden', 'brinkman_kind_id', 1)]},
-					 'brinkman': {'suffix': '_vorm',
+					 'brinkman_vorm': {'table_name':'publication_brinkman',
 								  'specifications': [('thesaurus_brinkmantrefwoorden', 'brinkman_kind_id', 0)]},
 					 'jaar_van_uitgave': {'table_name':'publication_basicinfo', 'feature_column': 'jaar_van_uitgave'},
 					 'role':{'table_name':'publication_contributors', 'feature_column':'role'}
 					 }
-	query = f"""WITH publication_subset AS(
-			SELECT t0.publication_ppn, t0.author_ppn, dataset_id
-			FROM publication_contributors t0
-			JOIN publication_datasplits	t1 ON t1.publication_ppn = t0.publication_ppn
-			JOIN datasplits	ON 	datasplits.datasplit_id = t1.datasplit_id 
-								AND datasplit = 'train'
-			WHERE t0.author_ppn	IS NOT NULL)"""
 	query = f"""WITH publication_subset AS(
 			SELECT t0.publication_ppn, t0.author_ppn
 			FROM publication_contributors_train_NBD t0
@@ -63,7 +56,6 @@ def author_aggregated_query():
 		suffix = specs['suffix'] if 'suffix' in specs else ''
 		query += f"""
 SELECT 
-	--t1.dataset_id,
 	t1.author_ppn, 
 	t2.{feature_column} AS term, 						
 	'{feature_name}{suffix}' AS term_description, 

--- a/demosauruswebapp/demosaurus/__init__.py
+++ b/demosauruswebapp/demosaurus/__init__.py
@@ -3,9 +3,12 @@ import os
 from flask import Flask, render_template, request, redirect, send_from_directory
 from flask_jsglue import JSGlue
 
-def create_app(test_config=None, SECRET_KEY='dev'):
+def create_app(test_config=None, SECRET_KEY='dev', instance_path = ''):
     # create and configure the app
-    app = Flask(__name__, instance_relative_config=True)
+    if not instance_path:
+        app = Flask(__name__, instance_relative_config=True)
+    else:
+        app = Flask(__name__, instance_path=instance_path)
     app.config.from_mapping(
         SECRET_KEY=SECRET_KEY,
         DATABASE=os.path.join(app.instance_path, 'demosaurus.sqlite'),

--- a/demosauruswebapp/demosaurus/link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/link_thesaurus.py
@@ -154,7 +154,7 @@ def candidate_query(author_name, train_only=False):
     q = "SELECT DISTINCT t1.author_ppn FROM author_fts5 t1"
     if train_only:
         q += " JOIN publication_contributors_train_NBD t2 ON t2.author_ppn = t1.author_ppn "
-    q += " WHERE name_normalized MATCH :searchkey"
+    q += " WHERE t1.name_normalized MATCH :searchkey"
     params = {'searchkey': '\"' + normalize_name(author_name)+ '\"'}
     return q, params
 

--- a/demosauruswebapp/demosaurus/link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/link_thesaurus.py
@@ -33,125 +33,109 @@ def thesaureer():
     if not author_name:
         candidates = pd.DataFrame()  # Without name, cannot select candidates
     else:
-        wrapped_publication, features_to_obtain = wrap_publication_info(request_args=request.args)
-        candidates = obtain_and_score_candidates(author_name, wrapped_publication, features_to_obtain)
+        wrapped_publication = wrap_publication_info(request_args=request.args)
+        candidates = obtain_and_score_candidates(author_name, wrapped_publication)
     return jsonify(json.loads(candidates.to_json(orient='records')))
 
 def wrap_publication_info(request_args):
-    features_to_obtain = { # scores that will be reported on in the end, plus which columns to use to compute them
-        'nominal': {'role':['role']},
-        'ordinal': {'year':['jaar_van_uitgave']},
-        'textual': {}}
     publication_genres = json.loads(request_args.get('publication_genres', '', type=str))
-    features_to_obtain['nominal']['genre'] = [genre for genre, identifiers in publication_genres.items() if len(identifiers)>0]
-
-    publication_features = {'jaar_van_uitgave': [request_args.get('publication_year', '', type=str)],
-                           'role': [request_args.get('contributor_role', '', type=str)], # might be more than one..
-                           #'title':[request_args.get('publication_title', '', type=str)] # not used atm
-                           }
-    publication_features.update({kind:[item['identifier'] for item in itemlist] for kind, itemlist in publication_genres.items()})
-
-    def cast_type(feature_value, feature_name):
-        if feature_name in ['NUGI_genre','NUR_rubriek','jaar_van_uitgave']:
-            return int(feature_value.strip())
-        else:
-            return feature_value.strip()
-
-    wrapped_publication = pd.DataFrame(
-        [pd.Series({feature: cast_type(value, feature), 'this_publication': 1}) for feature, value_list in publication_features.items() for
-         value in value_list])
-
-    return wrapped_publication, features_to_obtain
+    f_list = [(kind, item['identifier']) for kind, itemlist in publication_genres.items() for item in itemlist]
+    f_list.append(('role',request_args.get('contributor_role', '', type=str)))
+    try:
+        f_list.append(('jaar_van_uitgave', request_args.get('publication_year', type=int)))
+    except ValueError: # year is an empty string or otherwise not convertible to int
+        pass # omit it in the list
+    wrapped_publication = pd.DataFrame.from_records(f_list, columns=['term_description', 'term'])
+    wrapped_publication['this_publication'] = 1
+    return wrapped_publication
 
 def mask(a):
     return np.ma.MaskedArray(a, mask=np.isnan(a))
 
-def obtain_and_score_candidates(author_name, wrapped_publication, features_to_obtain):
-    candidates, similarity_data = obtain_candidates(author_name,
-        features=[f # flattened list for obtaining: interact with database just once
-                for f_kind, f_dict in features_to_obtain.items()
-                for f_name, f_list in f_dict.items()
-                for f in f_list])
-    if len(candidates) == 0:
+
+FEATURE_KINDS = {}
+FEATURE_KINDS.update({x:'nominal' for x in ['CBK_genre','NUGI_genre','NUR_rubriek',
+                                         'brinkman_vorm','brinkman_zaak', 'role']})
+FEATURE_KINDS.update({x:'ordinal' for x in ['jaar_van_uitgave']})
+
+FEATURE_GROUPS = {}
+FEATURE_GROUPS.update({x:'genre' for x in ['CBK_genre','NUGI_genre','NUR_rubriek',
+                                         'brinkman_vorm']})
+FEATURE_GROUPS.update({x:'subject' for x in ['brinkman_zaak']})
+FEATURE_GROUPS.update({x:'role' for x in ['role']})
+FEATURE_GROUPS.update({x:'year' for x in ['jaar_van_uitgave']})
+
+def score_feature(group):
+    """
+    Returns a tuple (score,confidence) holding score and confidence for a given feature.
+
+    Arguments:
+    group -- a Pandas GroupBy element that corresponds to an author
+             and a specific feature (e.g. Brinkman_vorm) and has columns
+             'term' with the feature value (e.g. '075629402')
+             'knownPublications' the number of known publications with that feature value
+             'this_publication' whether this publication has this feature value (0/1)
+    """
+    feature_name = group.term_description.iloc[0]
+    known = group.knownPublications.sum()
+    if known == 0 or group.this_publication.sum() == 0:
+        score = 0
+        confidence = 0
+    else:
+        if FEATURE_KINDS[feature_name] == 'nominal':
+            score = 1 - spatial_distance.cosine(group.knownPublications,
+                                                group.this_publication)
+        elif FEATURE_KINDS[feature_name] == 'ordinal':
+            years = pd.to_numeric(group.term)
+            this_value = years.loc[group.this_publication == 1].iloc[0]
+            mu, sigma = stats.norm.fit(
+                np.repeat(years, group.knownPublications))  # normal distrubtion fitted for author
+            sigma = max(5,
+                        sigma)  # sigma should be at least 5: publications are still likely (70%) 5 years from any known publication
+            top = stats.norm.pdf(mu, mu,
+                                 sigma)  # normalize by top of the distribution: we want a score of 1 for the mean
+            score = stats.norm.pdf(this_value, mu, sigma) / top
+        else:
+            score = -1
+        confidence = known / (known + 20)
+        # need approx. 20 datapoints to make a somewhat reliable estimate (50% sure)
+        # Temporary fix to get some estimate on reliability
+    return pd.Series({'score': score, 'confidence': confidence, 'term_category': FEATURE_GROUPS[feature_name]})
+
+def obtain_and_score_candidates(author_name, wrapped_publication):
+    candidates, similarity_data = obtain_candidates(author_name)
+    if len(candidates) == 0 or len(similarity_data) == 0:
         return candidates
     else:
-        scores = score_candidates(similarity_data,wrapped_publication,features_to_obtain)
-        candidates  = candidates.merge(scores,  left_on='author_ppn',  right_index=True)
+        scores = score_candidates(similarity_data,wrapped_publication)
+        candidates  = candidates.merge(scores,  left_on='author_ppn', right_index=True, how='left') # how='left' for all NTA entries (not just those with scores)
     return candidates.sort_values(ascending=False, by=['score','support'])
 
 
+def score_candidates(similarity_data, wrapped_publication):
+    scores = similarity_data.groupby('author_ppn') \
+        .apply(lambda author: \
+            pd.merge(wrapped_publication, author, how='outer') \
+                .fillna(0).groupby(['term_description'])\
+                .apply(score_feature) \
+                .groupby(['term_category'])
+                    .apply(lambda x:
+                        pd.Series([np.average(x.score, weights=x.confidence),
+                                   x.confidence.mean()],
+                                index=['score', 'confidence']))
+               ).unstack() # last groupby (term_categories) to column-index
+    scores.columns = [i[1] + '_' + i[0] for i in scores.columns.to_flat_index()] #flatten column index
 
-def score_candidates(similarity_data, wrapped_publication, features_to_obtain):
-    all_scores = pd.DataFrame(index=similarity_data.author_ppn.unique())
-    for f_kind, f_dict in features_to_obtain.items():
-        if len(f_dict) == 0:
-            continue
-        for feature_name, feature_list in f_dict.items():
-            partial_scores = {}
-            for feature in feature_list:
-                feature_data = \
-                    similarity_data[['author_ppn', feature, 'knownPublications']] \
-                        .dropna(subset=[feature]) \
-                        .merge(
-                        wrapped_publication[[feature, 'this_publication']] \
-                            .dropna(subset=[feature]),
-                        how='outer').fillna(0)
-                partial_scores[feature + '_score'], partial_scores[feature + '_confidence'] = score_functions[f_kind](
-                    feature_data,feature)
-
-            # combine partial scores into one single score for presentation
-            score_items = [feature + '_score' for feature in feature_list]
-            weight_items = [feature + '_confidence' for feature in feature_list]
-
-            score_confidence = pd.DataFrame(partial_scores).apply(
-                lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items], returned=True) if np.sum(row.loc[weight_items])>0 else (0,0), result_type='expand', axis=1)
-            # insert combined scores into candidates dataframe
-            all_scores = all_scores.merge(score_confidence,left_index=True, right_index=True).rename(
-                {0:feature_name+'_score', 1:feature_name + '_confidence'}, axis = 1)
-    # combine scores per feature group into a single overall score for ordering candidates
-    feature_list = ['genre','year']
+    feature_list = ['genre','year', 'role']
     score_items = [feature + '_score' for feature in feature_list]
     weight_items = [feature + '_confidence' for feature in feature_list]
-    all_scores['score'] = all_scores.apply(
+    # compute overall score
+    scores['score'] = scores.apply(
         lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items]), axis=1)
-    all_scores['support'] = all_scores.apply(
-        lambda row: np.sum(row.loc[weight_items]), axis=1)
-    return all_scores
+    scores['support'] = scores.apply(
+        lambda row: np.mean(row.loc[weight_items]), axis=1)
+    return scores
 
-
-def score_nominal(feature_data, feature_column):
-    """
-        Determine score (0-1) and confidence (0-1) for an author given the publication and their known publications
-        grouped:   a pandas DataFrameGroupBy with every group corresponding to an author with columns:
-                    rows correspond to feature occurrences, e.g. a specific subject term
-                    columns:
-                    - knownPublications (int): how many publications by that author are known to have the feature occurrence
-                    - this_publication (int 1/0): whether the publication under review has that feature occurrence
-        """
-    grouped = feature_data.groupby('author_ppn')
-    score = grouped.apply(lambda author:
-                1 - spatial_distance.cosine(author.knownPublications,
-                                            author.this_publication))
-    known = grouped['knownPublications'].sum()
-    confidence = known / (known + 20)
-        # need approx. 20 datapoints to make a somewhat reliable estimate (50% sure)
-        # Temporary fix to get some estimate on reliability
-    return score, confidence
-
-def score_ordinal(feature_data,feature_column):
-    this_value = feature_data.loc[lambda x: x.this_publication==1, feature_column].iloc[0]
-    grouped = feature_data.groupby('author_ppn')
-    # fit a normal distribution (described by my,sigma) for every author
-    mu_sigma = grouped.apply(lambda author:
-                             stats.norm.fit(np.repeat(author[feature_column], author.knownPublications)))
-    # sigma should be at least 5: publications are still likely (70%) 5 years from any known publication
-    # normalize by top of the distribution: we want a score of 1 for the mean
-    score = mu_sigma.apply(lambda row: stats.norm.pdf(this_value, max(5,row[0]), row[1])/stats.norm.pdf(row[0], row[0], row[1]))
-    known = grouped['knownPublications'].sum()
-    confidence = known / (known + 20)
-    return score, confidence
-
-score_functions = {'nominal':  score_nominal, 'ordinal': score_ordinal}
 
 def candidates_with_features_query(candidates_query):
     return "WITH candidates AS (" + candidates_query + """)
@@ -160,18 +144,12 @@ def candidates_with_features_query(candidates_query):
             LEFT JOIN author_isni t4 ON candidates.author_ppn = t4.author_ppn 
             GROUP BY author_NTA.author_ppn;"""
 
-def similarity_features_query(features, candidates_query):
-    query = "WITH candidates AS (" + candidates_query + ")\n"
-    for i, feature_i in enumerate(features):
-        if i > 0: query += ' UNION '
-        query += 'SELECT candidates.author_ppn, '
-        for j, feature_j in enumerate(features):
-            query += '{value} AS {feature},'.format(value= 'term_identifier' if i==j else 'NULL', feature=feature_j)
-        query += 'nPublications as knownPublications '
-        query += 'FROM candidates JOIN author_{feature}_NBD t{i} ON candidates.author_ppn = t{i}.author_ppn'.format(feature=feature_i, i=i)
+def aggregated_data_query(candidates_query):
+    query = f"WITH candidates AS ({candidates_query})\n"
+    query += "SELECT t1.* FROM author_aggregated t1 JOIN candidates ON t1.author_ppn = candidates.author_ppn\n"
     return query
 
-def candidate_query(author_name, train_only=True):
+def candidate_query(author_name, train_only=False):
     # TODO: implement extended search (with specifications) - only last name, spelling variations, etc.
     q = "SELECT DISTINCT t1.author_ppn FROM author_fts5 t1"
     if train_only:
@@ -180,73 +158,12 @@ def candidate_query(author_name, train_only=True):
     params = {'searchkey': '\"' + normalize_name(author_name)+ '\"'}
     return q, params
 
-def obtain_candidates(author_name, features):
+def obtain_candidates(author_name):
     candidates_query, params = candidate_query(author_name)
     q1 = candidates_with_features_query(candidates_query=candidates_query)
-    q2 = similarity_features_query(features=features, candidates_query=candidates_query)
+    q2 = aggregated_data_query(candidates_query=candidates_query)
     start = time.time()
     candidates = pd.read_sql_query(q1, params=params, con=get_db())
     similarity_data = pd.read_sql_query(q2, params=params, con=get_db())
     print('Obtain candidates - time elapsed:', time.time() - start)
     return candidates, similarity_data
-
-def score_names(authorshipItem, author_name):
-    return pd.Series([0, 0], index=['name_score', 'name_confidence'])
-
-    def normalized_levenshtein(s1, s2):
-        # normalized Levenshtein distance: normalize by the max of the lengths
-        l = float(max(len(s1), len(s2)))  # normalize by length, high score wins
-        return (l - nl_distance.edit_distance(s1, s2)) / l
-
-    def obtain_name_options(author_ppn):
-        query = "SELECT * FROM author_name_options WHERE author_ppn = :author_ppn"
-        return pd.read_sql_query(query, params={'author_ppn': author_ppn}, con=get_db())
-
-    name_options = obtain_name_options(authorshipItem.author_ppn)
-    name_options['fullnamescore'] = name_options['name'].apply(
-        lambda x: normalized_levenshtein(x, author_name.replace('@', '')))
-    if max(name_options['fullnamescore']) == 1:
-        name_score = 1
-        confidence = 1
-    else:
-        normalized_name = normalize_name(author_name.replace('@', ''))
-        confidence = normalized_name(normalized_name, author_name.replace('@', ''))
-        name_options['normalizedscore'] = name_options['name_normalized'].apply(
-            lambda x: normalized_levenshtein(x, normalized_name))
-        name_score = max(name_options['normalizedscore'])
-        if max(name_options['normalizedscore']) == 1:
-            name_score = .95
-            confidence = 1
-        else:
-            True
-
-    # family name should be rather similar: check levenshtein distance and normalize by length
-    if '@' in author_name:
-        nameparts = author_name.split('@')
-    else:
-        nameparts = author_name.split()
-    family_name = nameparts[-1]
-    given_name = ' '.join(nameparts[:-1])
-
-    familyNameScore = normalized_levenshtein(authorshipItem['foaf_familyname'], family_name)
-
-    confidence = 1
-    firstNameScore = 1
-    try:  # convert given name(s) to list
-        # an for author name, cn for candidate name
-        an, cn = [list(filter(None, re.split('\.|\s+', name))) for name in
-                  [authorshipItem['foaf_givenname'], given_name]]
-        firstNameScore *= 1 if len(an) == len(cn) else .8  # if number of given names differs, lower score
-    except:  # no reliable first name(s)
-        an, cn = [[], []]
-        firstNameScore = .5
-        confidence *= 0.5
-
-    for i in range(min(len(an), len(cn))):
-        if len(an[i]) == 1 or len(
-                cn[i]) == 1:  # Just initials: compare first letter only
-            firstNameScore *= 1 if an[i][0] == cn[i][0] else .5
-            confidence *= 0.8  # Gives less reliable score: confidence penalty
-        else:
-            firstNameScore *= normalized_levenshtein(an[i], cn[i])
-    return pd.Series([.5 * familyNameScore + .5 * firstNameScore, confidence], index=['name_score', 'name_confidence'])

--- a/demosauruswebapp/demosaurus/link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/link_thesaurus.py
@@ -1,7 +1,6 @@
 from flask import (
     Blueprint, flash, g, redirect, render_template, get_template_attribute, request, url_for, jsonify
 )
-#from ....dataprocessing import # dataprocessin .read_rdf import
 from demosauruswebapp.demosaurus.db import get_db
 import pandas as pd
 from nltk.metrics import distance as nl_distance
@@ -25,197 +24,166 @@ def normalize_name(name):
     name = ' '.join(name.split())  # single space separation
     return name
 
+class NoCandidatesFoundException(Exception):
+    pass
+
 @bp.route('/thesaureer/')
 def thesaureer():
     author_name = request.args.get('contributor_name', '', type=str)
     if not author_name:
-        author_options = pd.DataFrame() # Without name, cannot select candidates
+        candidates = pd.DataFrame()  # Without name, cannot select candidates
     else:
-        author_role = request.args.get('contributor_role', '', type=str)
-        publication_title = request.args.get('publication_title', '', type=str)
-        publication_genres = json.loads(request.args.get('publication_genres', '', type=str))
-        publication_year = {'jaar_van_uitgave': [request.args.get('publication_year', '', type=str)]}
-        author_options = thesaureer_this(author_name, author_role, publication_title, publication_genres, publication_year)
-    return author_options.to_json(orient='records')
+        wrapped_publication, features_to_obtain = wrap_publication_info(request_args=request.args)
+        candidates = obtain_and_score_candidates(author_name, wrapped_publication, features_to_obtain)
+    return jsonify(json.loads(candidates.to_json(orient='records')))
 
-def thesaureer_this(author_name, author_role, publication_title, publication_genres, publication_year):
-        db = get_db()
+def wrap_publication_info(request_args):
+    features_to_obtain = { # scores that will be reported on in the end, plus which columns to use to compute them
+        'nominal': {},#{'role':['role']},
+        'ordinal': {},#'year':['jaar_van_uitgave']},
+        'textual': {}}
+    publication_genres = json.loads(request_args.get('publication_genres', '', type=str))
+    features_to_obtain['nominal']['genre'] = [genre for genre, identifiers in publication_genres.items() if len(identifiers)>0]
 
-        searchkey = '@' in author_name
-        if searchkey:
-            candidates = "WITH candidates AS (SELECT author_ppn FROM author_fts5 WHERE searchkey MATCH :searchkey)\n"
-            matcher = normalize_name(author_name.split('@')[-1].strip('"'))
+    publication_features = {'jaar_van_uitgave': [request_args.get('publication_year', '', type=str)],
+                           'role': [request_args.get('contributor_role', '', type=str)], # might be more than one..
+                           #'title':[request_args.get('publication_title', '', type=str)] # not used atm
+                           }
+    publication_features.update({kind:[item['identifier'] for item in itemlist] for kind, itemlist in publication_genres.items()})
+
+    def cast_type(feature_value, feature_name):
+        if feature_name in ['NUGI_genre','NUR_rubriek','jaar_van_uitgave']:
+            return int(feature_value.strip())
         else:
-            candidates = "WITH candidates AS (SELECT author_ppn FROM author_fts5 WHERE normalized_name MATCH :searchkey)\n"
-            matcher = normalize_name(author_name)
-        start = time.time()
-        author_options = pd.read_sql_query(candidates + """SELECT author_NTA.* FROM candidates 
-        JOIN publication_contributors_train_NBD t2 ON t2.author_ppn = candidates.author_ppn  -- only authors that we have training data for
-        JOIN author_NTA ON candidates.author_ppn = author_NTA.author_ppn 
-        GROUP BY author_NTA.author_ppn;
-        """, params={'searchkey':'\"'+matcher+'\"'}, con = db)
-        print('Obtain candidates - time elapsed:', time.time()-start)
-        # Add scores to the candidates
-        if len(author_options)>0:
-            start = time.time()
-            author_options=pd.concat((author_options, author_options.apply(
-                lambda row: score_names(row, author_name), axis=1)), axis=1)
-            print('Score names - time elapsed:', time.time() - start)
-            author_options=pd.concat((author_options, author_options.apply(
-                lambda row: score_class_based(row['author_ppn'], publication_genres, 'genre'), axis=1)), axis=1)
-            #author_options = pd.concat((author_options, author_options.apply(
-#                lambda row: score_class_based(row['author_ppn'], publication_year, 'jvu'), axis=1)), axis=1)
-            author_options=pd.concat((author_options, author_options.apply(
-                lambda row: score_year(row['author_ppn'], publication_year), axis=1)), axis=1)
-            author_options = pd.concat((author_options, author_options.apply(
-                lambda row: score_style(None, None), axis=1)), axis=1)
-            author_options=pd.concat((author_options, author_options.apply(
-                lambda row: score_role(None,author_role), axis=1)), axis=1)
+            return feature_value.strip()
 
-            # Determine overall score for candidate: linear combination of scores, weighted by confidence
-            features = ['name','genre', 'jvu']
-            scores = [feature+'_score' for feature in features]
-            weights = [feature+'_confidence' for feature in features]
-            author_options['score']= author_options.apply(lambda row: np.average(row.loc[scores], weights=row.loc[weights]), axis=1)
+    wrapped_publication = pd.DataFrame(
+        [pd.Series({feature: cast_type(value, feature), 'this_publication': 1}) for feature, value_list in publication_features.items() for
+         value in value_list])
 
-            # Sort candidates by score
-            author_options.sort_values(by='score', ascending=False, inplace=True)
+    return wrapped_publication, features_to_obtain
 
-        return author_options
+def mask(a):
+    return np.ma.MaskedArray(a, mask=np.isnan(a))
 
+def obtain_and_score_candidates(author_name, wrapped_publication, features_to_obtain):
+    features = [f
+                for f_kind, f_dict in features_to_obtain.items()
+                for f_name, f_list in f_dict.items()
+                for f in f_list] # flattened list for obtaining: interact with database just once
 
-def normalized_levenshtein(s1,s2):
-    # normalized Levenshtein distance: normalize by the max of the lengths
-    l = float(max(len(s1), len(s2))) # normalize by length, high score wins
-    return  (l - nl_distance.edit_distance(s1, s2)) / l         
-    
+    candidates, similarity_data = obtain_candidates(author_name, features=features)
+    if len(candidates) == 0:
+        return candidates
 
-def score_names(authorshipItem, author_name):
-    # family name should be rather similar: check levenshtein distance and normalize by length
-    if '@' in author_name:
-        nameparts = author_name.split('@')
-    else:
-        nameparts = author_name.split()
-    family_name = nameparts[-1]
-    given_name = ' '.join(nameparts[:-1])
+    for f_kind, f_dict in features_to_obtain.items():
+        if len(f_dict) == 0:
+            continue
+        feature_list = [f for f_list in f_dict.values() for f in f_list]
+        # flattened list for obtaining partial scores: same for all nominal features/all ordinal features/etc
+        if f_kind == 'nominal': score_function = score_nominal
+        elif f_kind == 'ordinal': score_function = score_ordinal
+        else: score_function = None # todo
+        partial_scores = score_function(similarity_data, wrapped_publication, feature_list)
 
-    familyNameScore =  normalized_levenshtein(authorshipItem['foaf_familyname'],family_name)
-
-    confidence = 1
-    firstNameScore = 1
-    try: # convert given name(s) to list
-        # an for author name, cn for candidate name
-        an,cn= [list(filter(None,re.split('\.|\s+', name))) for name in [authorshipItem['foaf_givenname'],given_name]]
-        firstNameScore *= 1 if len(an)==len(cn) else .8 # if number of given names differs, lower score
-    except: # no reliable first name(s)
-        an, cn = [[],[]]
-        firstNameScore=.5
-        confidence *= 0.5
-    
-    for i in range(min(len(an),len(cn))):
-        if len(an[i])==1 or len(cn[i])==1: # Just initials: compare first letter only                                        
-            firstNameScore *= 1 if an[i][0] == cn[i][0] else .5
-            confidence *= 0.8 # Gives less reliable score: confidence penalty 
-        else:
-            firstNameScore *= normalized_levenshtein(an[i],cn[i])
-    return pd.Series([.5*familyNameScore+.5*firstNameScore, confidence], index = ['name_score', 'name_confidence'])
+        for feature_name, feature_list in f_dict.items():
+            # combine partial scores into one single score for presentation
+            score_items = [feature + '_score' for feature in feature_list]
+            weight_items = [feature + '_confidence' for feature in feature_list]
+            score_confidence = partial_scores.apply(
+                lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items], returned=True), result_type='expand', axis=1)
+            candidates = candidates.merge(score_confidence, left_on='author_ppn',right_index=True).rename(
+                {0:feature_name+'_score', 1:feature_name + '_confidence'}, axis = 1)
+    feature_list = ['genre']
+    score_items = [feature + '_score' for feature in feature_list]
+    weight_items = [feature + '_confidence' for feature in feature_list]
+    candidates['score'] = candidates.apply(
+        lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items]), axis=1)
+    candidates['support'] = candidates.apply(
+        lambda row: np.sum(row.loc[weight_items]), axis=1)
+    return candidates.sort_values(ascending=False, by=['score','support'])
 
 
-def obtain_similarity_data(author_ppn, features):
-    # obtain accumulated data for author
-    # from author views (see repo/data-processing/author_views.py)
-    #try:
-    query = ''
+def score_nominal(similarity_data, this_publication, features):
+    """
+        Determine score (0-1) and confidence (0-1) for an author given the publication and their known publications
+        Based on information in fields corresponding to <features>
+        this_publication:   the information of the publication to be compared to
+                            a pandas DataFrame with in every row:
+                             - one non-NaN identifier
+                             - the corresponding count (1)
+        similarity_data:    the information about authors to be compared to
+                            a pandas DataFrame with in every row:
+                             - the pica identifier (PPN) for an author
+                             - one non-NaN identifier
+                             - the corresponding count for that author
+        """
+    scores = pd.DataFrame(index=similarity_data.author_ppn.unique())
+    for feature in features:
+        feature_data = \
+            similarity_data[['author_ppn', feature, 'knownPublications']] \
+                .dropna(subset=[feature]) \
+            .merge(
+                this_publication[[feature, 'this_publication']] \
+                    .dropna(subset=[feature]),
+                how='outer').fillna(0)
+        grouped = feature_data.groupby('author_ppn')
+        scores[feature+'_score'] = grouped.apply(lambda author:
+                1 - spatial_distance.cosine(author.knownPublications,
+                                            author.this_publication))
+        known = grouped['knownPublications'].sum()
+        scores[feature + '_confidence'] = known / (known + 20)
+            # need approx. 20 datapoints to make a somewhat reliable estimate (50% sure)
+            # Temporary fix to get some estimate on reliability
+        #scores[feature + '_confidence'] = scores[feature + '_confidence'].fillna(0)
+    return scores
+
+def score_ordinal(similarity_data, this_publication, features):
+    scores = pd.DataFrame(index=similarity_data.author_ppn.unique())
+    for feature in features:
+        continue
+        # do stuff
+    return scores
+
+
+def candidates_with_features_query(candidates_query):
+    return "WITH candidates AS (" + candidates_query + """)
+            SELECT author_NTA.*, t4.identifier AS isni FROM candidates 
+            JOIN author_NTA ON candidates.author_ppn = author_NTA.author_ppn
+            LEFT JOIN author_isni t4 ON candidates.author_ppn = t4.author_ppn 
+            GROUP BY author_NTA.author_ppn;"""
+
+def similarity_features_query(features, candidates_query):
+    query = "WITH candidates AS (" + candidates_query + ")\n"
     for i, feature_i in enumerate(features):
         if i > 0: query += ' UNION '
-        query += 'SELECT '
+        query += 'SELECT candidates.author_ppn, '
         for j, feature_j in enumerate(features):
-            if i == j:
-                query += 'term_identifier AS ' + feature_j + ','
-            else:
-                query += 'NULL AS ' + feature_j + ','
+            query += '{value} AS {feature},'.format(value= 'term_identifier' if i==j else 'NULL', feature=feature_j)
         query += 'nPublications as knownPublications '
-        query += 'FROM ' + 'author_' + feature_i + '_NBD '
-        query += 'WHERE author_ppn = :author_ppn'
-    data = pd.read_sql_query(query, params={'author_ppn':author_ppn}, con = get_db())
-    #except e:
-    #    print('PROBLEM', e) 
-    #TODO: proper exception handling (return exception to caller!)
-    return data
+        query += 'FROM candidates JOIN author_{feature}_NBD t{i} ON candidates.author_ppn = t{i}.author_ppn'.format(feature=feature_i, i=i)
+    return query
 
-def score_class_based(author_ppn, publication_classes, name):
-    """
-    Determine score (0-1) and confidence (0-1) for an author given the publication and their known publications
-    Based on information in fields corresponding to items in publication_classes (e.g. genres, subjects, ...)
-    author_ppn: the pica identifier of the candidate author (string)
-    publication_classes: the information of the publication to be compared to
-                         a dictionary of lists: 
-                            keys are class names that correspond to database information (e.g. "CBK_genre")
-                            values are a list of identifiers that correspond to publication (e.g. ["330", "135", "322", "334"])
-    name: a string that indicates how to interpret the score (e.g. "genre")
-    """
-    if sum([len(v) for k,v in publication_classes.items()]) == 0:
-        # Nothing to base score on. Return zero or something else?
-        score = 0
-        confidence = 0 
-    else: 
-        # Obtain a list of known publication counts from the database
-        known_info = obtain_similarity_data(author_ppn, publication_classes.keys())
-        if len(known_info) == 0:
-            # no information available to make a sane comparison
-            score = 0
-            confidence = 0
-        else: 
-            # Add a column with the new publication to compare with
-            for c,l in publication_classes.items():
-                for v in l:
-                    if type(v)== dict:
-                        try: known_info.loc[known_info[c]==v['identifier'],'newPublication']=1
-                        except: print('Cannot add publication info to dataframe for comparison')
-                    else:
-                        try: known_info.loc[known_info[c]==v,'newPublication']=1
-                        except: print('Cannot add publication info to dataframe for comparison')
-            # score = 1- cosine distance between array of known publications and new publication
-            # intuition:
-            # if there are no overlapping genres, distance = 1 so score is 0
-            # if there is little overlap, the score is close to 0
-            # if the new publication is very similar to known publications, the score is close to 1       
-            known_info = known_info.fillna(0)
+def candidate_query(author_name, train_only=True):
+    # TODO: implement extended search (with specifications) - only last name, spelling variations, etc.
+    q = "SELECT DISTINCT t1.author_ppn FROM author_fts5 t1"
+    if train_only:
+        q += " JOIN publication_contributors_train_NBD t2 ON t2.author_ppn = t1.author_ppn "
+    q += " WHERE name_normalized MATCH :searchkey"
+    params = {'searchkey': '\"' + normalize_name(author_name)+ '\"'}
+    return q, params
 
-            try:
-                score = 1 - spatial_distance.cosine(known_info.knownPublications, known_info.newPublication)
-                assert not np.isnan(score)
-                known = known_info.knownPublications.sum()
-                confidence= known/(known+20) # need approx. 20 datapoints to make a somewhat reliable estimate (50% sure)
-                # Temporary fix to get some estimate on reliability
-            except:
-                #print('class based score is undefined for', author_ppn, publication_classes)
-                score = 0
-                confidence = 0
-
-    return pd.Series([score, confidence], index = [name+'_score', name+'_confidence'])
-    
-def score_style(author_record, author_context):
-    #score=max(min(np.random.normal(0.5,0.1),1),0)
-    #confidence=max(min(np.random.normal(0.4, 0.1),0.9),0.1)
-    score = 0
-    confidence = 0 
-    return pd.Series([score, confidence], index = ['style_score', 'style_confidence'])
-
-
-def score_role(author_record, author_context):
-    if not author_context or not author_record :
-        score = 0
-        confidence = 0
-    else:
-        score = 0
-        confidence = 0 
-        # score=max(min(np.random.normal(0.7, 0.1),1),0)
-        # confidence=max(min(np.random.normal(0.4, 0.1),0.9),0.1)
-    return pd.Series([score, confidence], index = ['role_score', 'role_confidence'])
+def obtain_candidates(author_name, features):
+    candidates_query, params = candidate_query(author_name)
+    q1 = candidates_with_features_query(candidates_query=candidates_query)
+    q2 = similarity_features_query(features=features, candidates_query=candidates_query)
+    start = time.time()
+    candidates = pd.read_sql_query(q1, params=params, con=get_db())
+    similarity_data = pd.read_sql_query(q2, params=params, con=get_db())
+    print('Obtain candidates - time elapsed:', time.time() - start)
+    return candidates, similarity_data
 
 def score_year(author_ppn, publication_year):
-
     try:
         year = int (publication_year['jaar_van_uitgave'][0])
         known_info = obtain_similarity_data(author_ppn, publication_year)
@@ -238,3 +206,63 @@ def score_year(author_ppn, publication_year):
 
     return pd.Series([score, confidence], index=['jvu_score', 'jvu_confidence'])
 
+def score_names(authorshipItem, author_name):
+    return pd.Series([0, 0], index=['name_score', 'name_confidence'])
+
+    def normalized_levenshtein(s1, s2):
+        # normalized Levenshtein distance: normalize by the max of the lengths
+        l = float(max(len(s1), len(s2)))  # normalize by length, high score wins
+        return (l - nl_distance.edit_distance(s1, s2)) / l
+
+    def obtain_name_options(author_ppn):
+        query = "SELECT * FROM author_name_options WHERE author_ppn = :author_ppn"
+        return pd.read_sql_query(query, params={'author_ppn': author_ppn}, con=get_db())
+
+    name_options = obtain_name_options(authorshipItem.author_ppn)
+    name_options['fullnamescore'] = name_options['name'].apply(
+        lambda x: normalized_levenshtein(x, author_name.replace('@', '')))
+    if max(name_options['fullnamescore']) == 1:
+        name_score = 1
+        confidence = 1
+    else:
+        normalized_name = normalize_name(author_name.replace('@', ''))
+        confidence = normalized_name(normalized_name, author_name.replace('@', ''))
+        name_options['normalizedscore'] = name_options['name_normalized'].apply(
+            lambda x: normalized_levenshtein(x, normalized_name))
+        name_score = max(name_options['normalizedscore'])
+        if max(name_options['normalizedscore']) == 1:
+            name_score = .95
+            confidence = 1
+        else:
+            True
+
+    # family name should be rather similar: check levenshtein distance and normalize by length
+    if '@' in author_name:
+        nameparts = author_name.split('@')
+    else:
+        nameparts = author_name.split()
+    family_name = nameparts[-1]
+    given_name = ' '.join(nameparts[:-1])
+
+    familyNameScore = normalized_levenshtein(authorshipItem['foaf_familyname'], family_name)
+
+    confidence = 1
+    firstNameScore = 1
+    try:  # convert given name(s) to list
+        # an for author name, cn for candidate name
+        an, cn = [list(filter(None, re.split('\.|\s+', name))) for name in
+                  [authorshipItem['foaf_givenname'], given_name]]
+        firstNameScore *= 1 if len(an) == len(cn) else .8  # if number of given names differs, lower score
+    except:  # no reliable first name(s)
+        an, cn = [[], []]
+        firstNameScore = .5
+        confidence *= 0.5
+
+    for i in range(min(len(an), len(cn))):
+        if len(an[i]) == 1 or len(
+                cn[i]) == 1:  # Just initials: compare first letter only
+            firstNameScore *= 1 if an[i][0] == cn[i][0] else .5
+            confidence *= 0.8  # Gives less reliable score: confidence penalty
+        else:
+            firstNameScore *= normalized_levenshtein(an[i], cn[i])
+    return pd.Series([.5 * familyNameScore + .5 * firstNameScore, confidence], index=['name_score', 'name_confidence'])

--- a/demosauruswebapp/demosaurus/link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/link_thesaurus.py
@@ -39,7 +39,7 @@ def thesaureer():
 
 def wrap_publication_info(request_args):
     features_to_obtain = { # scores that will be reported on in the end, plus which columns to use to compute them
-        'nominal': {},#{'role':['role']},
+        'nominal': {'role':['role']},
         'ordinal': {'year':['jaar_van_uitgave']},
         'textual': {}}
     publication_genres = json.loads(request_args.get('publication_genres', '', type=str))
@@ -102,8 +102,9 @@ def score_candidates(similarity_data, wrapped_publication, features_to_obtain):
             # combine partial scores into one single score for presentation
             score_items = [feature + '_score' for feature in feature_list]
             weight_items = [feature + '_confidence' for feature in feature_list]
+
             score_confidence = pd.DataFrame(partial_scores).apply(
-                lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items], returned=True), result_type='expand', axis=1)
+                lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items], returned=True) if np.sum(row.loc[weight_items])>0 else (0,0), result_type='expand', axis=1)
             # insert combined scores into candidates dataframe
             all_scores = all_scores.merge(score_confidence,left_index=True, right_index=True).rename(
                 {0:feature_name+'_score', 1:feature_name + '_confidence'}, axis = 1)

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -120,18 +120,31 @@ function search_for_candidates(index){
           return (row.birthyear|| '') +'-'+(row.deathyear|| '');
         }},
         { "data" : "score", render: function ( data, type, row ) {
-          try {
-            return row.score.toFixed(2);
-          }
-          catch (TypeError) {
-            return row.score
-          }
-        }, className: "match_cell"}
+          var score_show = row.score===null?row.score:Math.round(100*row.score)+'%';
+          var score_hover = '<div title="Alle subscores"</div>'
+          return type === 'display'? score_hover + score_show : score_show;
+//
+          //return score_show;
+        }, className: "match_cell"},
       ],
        "rowCallback": function( row, data, index ) {
          if (! isNaN(data.score)) {
             $('td.match_cell', row).css('background-color', getColorForPercentage(data.score));
          }
+         var score_hover = '<div><table><thead><tr><th/><th>Score</th><th>Confidence</th></tr></thead><tbody>'
+         var scores_to_show = [['Genre',data.genre_score,data.genre_confidence], ['Rol',data.role_score,data.role_confidence],['Jaar',data.year_score,data.year_confidence]];
+
+         for (var i=0; i < scores_to_show.length; i++) {
+           console.log(scores_to_show[i])
+           scorename = scores_to_show[i][0]
+           subscore = scores_to_show[i][1]
+           scorestring = subscore===null?subscore:Math.round(100*subscore)+'%'
+           subconfidence = scores_to_show[i][2]
+           confidencestring = subconfidence===null?subconfidence:Math.round(100*subconfidence)+'%'
+           score_hover += '<tr><td>'+scorename+'</td><td>'+scorestring+'</td><td>'+confidencestring+'</td></tr>'
+         }
+         score_hover += '</tbody></table></div>'
+        $('td.match_cell', row).tooltip({content: score_hover})
         }
     });
   }
@@ -144,11 +157,5 @@ $('#candidate_list').on('click', 'td.editor-delete', function () {
     } );
 
 $('#candidate_list').on('click', 'td.pick-author', function () {
-   choose_ppn($(this).text())
+   $('#ppn_'+focus_index).val($(this).text());
     } );
-
-
-function choose_ppn(ppn) {
-  console.log('Choose', ppn);
-  $('#ppn_'+focus_index).val(ppn);
-}

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -123,7 +123,7 @@ function search_for_candidates(index){
           return (row.birthyear|| '') +'-'+(row.deathyear|| '');
         }},
         { "data" : "score", render: function ( data, type, row ) {
-          var score_show = row.score===null?'':Math.round(100*row.score)+'%';
+          var score_show = (row.score===null || typeof(row.score)==='undefined')?'':Math.round(100*row.score)+'%';
           var score_hover = '<div title="Alle subscores"</div>' // I have no clue why deleting this bit renders the tooltip created in rowCallback useless..
           return type === 'display'? score_hover + score_show : score_show;
         }, className: "match_cell"},
@@ -141,7 +141,7 @@ function search_for_candidates(index){
            subscore = scores_to_show[i][1]
            scorestring = subscore===null?subscore:Math.round(100*subscore)+'%'
            subconfidence = scores_to_show[i][2]
-           confidencestring = subconfidence===null?'':'('+Math.round(100*subconfidence)+'% zeker)'
+           confidencestring = (subconfidence===null || typeof(subconfidence)==='undefined')?'':'('+Math.round(100*subconfidence)+'% zeker)'
            score_hover += '<tr><th>'+scorename+'</th><td style="text-align:right">'+scorestring+'</td><td style="text-align:right">'+confidencestring+'</td></tr>'
          }
          score_hover += '</tbody></table></div>'

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -130,14 +130,19 @@ function search_for_candidates(index){
           return (row.birthyear|| '') +'-'+(row.deathyear|| '');
         }},
         { "data" : "score", render: function ( data, type, row ) {
-          if (isNaN(row.score)) {
+          try {
+            return row.score.toFixed(2);
+          }
+          catch (TypeError) {
             return row.score
           }
-          else
-            $('td', row).css('color', getColorForPercentage(row.score));
-            return row.score.toFixed(2);
         }, className: "match_cell"}
-      ]
+      ],
+       "rowCallback": function( row, data, index ) {
+         if (! isNaN(data.score)) {
+            $('td.match_cell', row).css('background-color', getColorForPercentage(data.score));
+         }
+        }
     });
   }
 

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -111,14 +111,12 @@ function search_for_candidates(index){
         { "data" : "author_ppn", className: "pick-author"
         },
         { "data" : "foaf_name"
-        //, render: function( data, type, row ){
-        //  try {var role = $('#role_'+index).val().match(/\[(.*?)\]/)[1];}
-        //  catch(e) {var role = null; }
-        //  var context = {'Title':$('#publication_title').textContent, 'Role':role};
-        //  return $('<a class="action"  title="Details" href="#" onClick="open_popup(\''+Flask.url_for('contributor.authorpage', context)+'\')"; return false;>').text(row.foaf_name)
-          // For some reason, the above does not work: it cannot find the proper endpoint for contributor.authorpage
-          // Also, how does the author_ppn get passed again??
-        //}
+          , render: function( data, type, row ){
+            try {var role = $('#role_'+index).val().match(/\[(.*?)\]/)[1];}
+              catch(e) {var role = null; }
+              var context = {'id':row.author_ppn, 'Title':$('#publication_title').textContent, 'Role':role};
+              return '<a class="action"  title="Details" href="#" onClick="open_popup(\''+Flask.url_for('contributor.authorpage', context)+'\')"; return false;>'+row.foaf_name+'</a>';
+        }
         },
         { "data" : "isni", render: function( data, type, row ){
           return row.isni?'X':'-';
@@ -160,35 +158,6 @@ $('#candidate_list').on('click', 'td.pick-author', function () {
    choose_ppn($(this).text())
     } );
 
-
-
-function thesaureer_response(response, contributor_row) {
-  // Determine context for display on contributor page
-  try {var role = $('#role_'+contributor_row).val().match(/\[(.*?)\]/)[1];}
-  catch(e) {var role = null; }
-  var context = {'Title':$('#publication_title').val(), 'Role':role};
-
-  for(var i = 0; i<response.length; i++){
-    //add_to_candidate_list(response[i], context);
-    console.log('add_to_candidate_list now')
-    console.log(response[i])
-    var years = [response[i].birthyear,'-',response[i].deathyear].join('');
-    context['id']=response[i].author_ppn;
-    color = getColorForPercentage(response[i].score);
-
-    $("#candidate_list > tbody").append($('<tr onclick="choose_ppn(\''+response[i].author_ppn+'\')"; return false;>')
-    .append($('<td>').append('<input onclick="delete_row(this);" type="button" value="&#xf2ed;" class="fas fa-trash-alt" title="Verwijder naam" padding="0px">'))
-    .append($('<td class="ppn_cell" >').text(response[i].author_ppn))
-    .append($('<td class="name_cell">')
-    .append($('<a class="action"  title="Details" href="#" onClick="open_popup(\''+Flask.url_for('contributor.authorpage', context)+'\')"; return false;>')
-    .text(response[i].foaf_name)))
-    .append($('<td>').html((response[i].isni?'&#10003;':'')))
-    .append($('<td class="name_cell" title="'+candidate_note(response[i])+'">').text(candidate_note(response[i])).tooltip())
-    .append($('<td class="years_cell">')
-    .text(years))
-    .append($('<td class="match_cell" data-rij="' + i + '" id="thesMatchTt" style="background-color:'+color+'">').text(Math.round(100*response[i].score)))
-    )
-  };
   // Hover div on Match with sub-scores.
   $('.match_cell').hover(
   // ipv hover, kolommen wel/niet tonen? https://datatables.net/examples/api/show_hide.html

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -4,6 +4,7 @@ var main_author = true;
 
 
 $(document).ready(function() {
+  $("#candidate_list").hide();
   //if (pilotMode) {
   if (false){
   console.log('in Pilot mode: create first empty row')
@@ -19,6 +20,7 @@ $(document).ready(function() {
       }
   }
   top_main_author();
+
 });
 
 function add_contributor_row(name="", role="") {
@@ -70,6 +72,7 @@ function candidate_note(candidaterow){
 }
 
 function search_for_candidates(index){
+  $("#candidate_list").show();
   if ( $.fn.dataTable.isDataTable('#candidate_list') ) {
       $('#candidate_list').DataTable().destroy();
     }
@@ -120,18 +123,16 @@ function search_for_candidates(index){
           return (row.birthyear|| '') +'-'+(row.deathyear|| '');
         }},
         { "data" : "score", render: function ( data, type, row ) {
-          var score_show = row.score===null?row.score:Math.round(100*row.score)+'%';
-          var score_hover = '<div title="Alle subscores"</div>'
+          var score_show = row.score===null?'':Math.round(100*row.score)+'%';
+          var score_hover = '<div title="Alle subscores"</div>' // I have no clue why deleting this bit renders the tooltip created in rowCallback useless..
           return type === 'display'? score_hover + score_show : score_show;
-//
-          //return score_show;
         }, className: "match_cell"},
       ],
        "rowCallback": function( row, data, index ) {
          if (! isNaN(data.score)) {
             $('td.match_cell', row).css('background-color', getColorForPercentage(data.score));
          }
-         var score_hover = '<div><table><thead><tr><th/><th>Score</th><th>Confidence</th></tr></thead><tbody>'
+         var score_hover = '<div><table><tbody>'
          var scores_to_show = [['Genre',data.genre_score,data.genre_confidence], ['Rol',data.role_score,data.role_confidence],['Jaar',data.year_score,data.year_confidence]];
 
          for (var i=0; i < scores_to_show.length; i++) {
@@ -140,8 +141,8 @@ function search_for_candidates(index){
            subscore = scores_to_show[i][1]
            scorestring = subscore===null?subscore:Math.round(100*subscore)+'%'
            subconfidence = scores_to_show[i][2]
-           confidencestring = subconfidence===null?subconfidence:Math.round(100*subconfidence)+'%'
-           score_hover += '<tr><td>'+scorename+'</td><td>'+scorestring+'</td><td>'+confidencestring+'</td></tr>'
+           confidencestring = subconfidence===null?'':'('+Math.round(100*subconfidence)+'% zeker)'
+           score_hover += '<tr><th>'+scorename+'</th><td style="text-align:right">'+scorestring+'</td><td style="text-align:right">'+confidencestring+'</td></tr>'
          }
          score_hover += '</tbody></table></div>'
         $('td.match_cell', row).tooltip({content: score_hover})

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -62,15 +62,6 @@ function deactivate_rows() {
   $(".role").css("backgroundColor","");    
 }
 
-  // Hover over Match column shows scores.
-  $(function() {
-      $('#authorMatchTt').tooltip({ content: $('#authorMatchHover').html() });
-  });
-
-  $(function() {
-      $('#thesMatchTt').tooltip({ content: $('#thesMatchHover').html() });
-  });
-
 function candidate_note(candidaterow){
   return ''
     +(candidaterow.skopenote_nl || '')+' '
@@ -108,7 +99,7 @@ function search_for_candidates(index){
       },
       columns: [
         { "data": null, className: "dt-center editor-delete", defaultContent: '<i class="fa fa-trash"/>', orderable: false},
-        { "data" : "author_ppn", className: "pick-author"
+        { "data" : "author_ppn", className: "pick-author highlight", tooltip: "<span class='name_column_tip'>Kies auteur</span>"
         },
         { "data" : "foaf_name"
           , render: function( data, type, row ){
@@ -146,7 +137,6 @@ function search_for_candidates(index){
   }
 
 $('#candidate_list').on('click', 'td.editor-delete', function () {
-   console.log('Delete',this)
         candidates
           .row( $(this).parents('tr') )
           .remove()
@@ -154,54 +144,9 @@ $('#candidate_list').on('click', 'td.editor-delete', function () {
     } );
 
 $('#candidate_list').on('click', 'td.pick-author', function () {
-   console.log('Pick',this)
    choose_ppn($(this).text())
     } );
 
-  // Hover div on Match with sub-scores.
-  $('.match_cell').hover(
-  // ipv hover, kolommen wel/niet tonen? https://datatables.net/examples/api/show_hide.html
-  function() {
-    console.log('hover over match')
-    var tooltipValues = [];
-    //$('#tttb2').text(Math.round(response[$(this).data("rij")]["role_score"]*100) + '%');
-    //$('#tttb3').text(Math.round(response[$(this).data("rij")]["role_confidence"]*100) + '%');
-
-    $('#tttb5').text(Math.round($(this).data["genre_score"]*100) + '%');
-    $('#tttb6').text(Math.round($(this).data["genre_confidence"]*100) + '%');
-
-    $('#tttb14').text(Math.round($(this).data["name_score"]*100) + '%');
-    $('#tttb15').text(Math.round($(this).data["name_confidence"]*100) + '%');
-
-    $('#tttb8').text(Math.round($(this).data["jvu_score"]*100) + '%');
-    $('#tttb9').text(Math.round($(this).data["jvu_confidence"]*100) + '%');
-
-    var tooltip = $("<div class='tooltip'>" + $('#thesMatchHover').html() + "</div>")
-      .css({
-        'color': '#363838',
-        'position': 'absolute',
-        'zIndex': '99999',
-        'width': '200px',
-        'right':'150px',
-        'height': '150px',
-        'background-color': 'rgba(34, 204, 240, 0)',
-      });
-    $(this).append(tooltip);
-  },
-  function() {
-    $('.tooltip').remove();
-    }
-  );
-  $('#candidate_list').DataTable({ordering: false});
-
-  $('#candidate_list').on('click', '.fas.fa-trash-alt', function(){
-    var cl = $('#candidate_list').DataTable();
-    cl
-      .row($(this).parents('tr'))
-      .remove()
-      .draw();
-  });
-};
 
 function choose_ppn(ppn) {
   console.log('Choose', ppn);

--- a/demosauruswebapp/demosaurus/static/js/contributors-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/contributors-tab.js
@@ -108,7 +108,8 @@ function search_for_candidates(index){
       },
       columns: [
         { "data": null, className: "dt-center editor-delete", defaultContent: '<i class="fa fa-trash"/>', orderable: false},
-        { "data" : "author_ppn" },
+        { "data" : "author_ppn", className: "pick-author"
+        },
         { "data" : "foaf_name"
         //, render: function( data, type, row ){
         //  try {var role = $('#role_'+index).val().match(/\[(.*?)\]/)[1];}
@@ -153,6 +154,13 @@ $('#candidate_list').on('click', 'td.editor-delete', function () {
           .remove()
           .draw();
     } );
+
+$('#candidate_list').on('click', 'td.pick-author', function () {
+   console.log('Pick',this)
+   choose_ppn($(this).text())
+    } );
+
+
 
 function thesaureer_response(response, contributor_row) {
   // Determine context for display on contributor page
@@ -224,7 +232,6 @@ function thesaureer_response(response, contributor_row) {
       .remove()
       .draw();
   });
-
 };
 
 function choose_ppn(ppn) {

--- a/demosauruswebapp/demosaurus/static/js/export-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/export-tab.js
@@ -1,6 +1,6 @@
 function export_info() {
   console.log('Export button')
-  deactivate_rows();
+  //deactivate_rows();
   $("#export > #message").empty();
 
 //        $('#thesaureer_title').text('KMCS:');
@@ -9,10 +9,7 @@ function export_info() {
     subjects = export_keywords();
 
     $('#export_content').html(authors+subjects);
-
-
   }
-
 
 function export_authors(){
   var allnames = true;

--- a/demosauruswebapp/demosaurus/static/js/my_functions.js
+++ b/demosauruswebapp/demosaurus/static/js/my_functions.js
@@ -20,9 +20,6 @@ function open_popup (url, width=700, height=400) {
 
 function openTab(evt, tabName){
     // Declare all variables
-
-  console.log('Open tab', tabName)
-
   var i, tabcontent, tablinks;
 
   // Get all elements with class="tabcontent" and hide them
@@ -31,15 +28,8 @@ function openTab(evt, tabName){
     tabcontent[i].style.display = "none";
   }
   document.getElementById(tabName).style.display = "block";
-  
-//  // When switching tabs, also show the corresponding results (2nd half of page).
-//  // FIX: doesn't show back after hiding, .style.display = "block"; ?
-//  bottomcontent = document.getElementsByClassName("bottomcontent");
-//  for (i = 0; i < bottomcontent.length; i++) {
-//    bottomcontent[i].style.display = "none";
-//  }
 
-  // Get all elements with class="tablinks" and remove the class "active"
+   // Get all elements with class="tablinks" and remove the class "active"
   tablinks = document.getElementsByClassName("tablinks");
   for (i = 0; i < tablinks.length; i++) {
     tablinks[i].className = tablinks[i].className.replace(" active", "");
@@ -76,7 +66,6 @@ var getColorForPercentage = function(this_perc, saturation=1.0, low=0.5) {
     };
     return 'rgba(' + [color.r, color.g, color.b, saturation].join(',') + ')';
   };
-  
 
   // DataTabel.js init interactive tables.
   $(document).ready( function () {
@@ -85,6 +74,4 @@ var getColorForPercentage = function(this_perc, saturation=1.0, low=0.5) {
       "pageLength":20,
       "searching": true
     } );
-
-
   });

--- a/demosauruswebapp/demosaurus/static/js/subjects-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/subjects-tab.js
@@ -4,21 +4,23 @@ $(document).ready(function() {
   // Do not pre-fill the subject terms
   }
   else{
-      console.log(genres);
+      console.log('genres', genres);
 
-      genreCategories = ['brinkman', 'CBK_genre'];
+      genreCategories = ['brinkman_vorm', 'CBK_genre'];
       for (var category of genreCategories){
-        listOfsubjects = genres[category];
-        for (var subject of listOfsubjects){
+        listOfGenres = genres[category];
+        table_name = category.includes('brinkman')? 'brinkman':category
+        for (var subject of listOfGenres){
             subjectString = subject['identifier']+' - '+subject['term'];
-            addSubjectRow(category, subject['term'], subject['identifier']);
+            addSubjectRow(table_name, 'vorm', subject['term'], subject['identifier']);
         }
       }
-      subjectCategories = ['brinkman'];
+      subjectCategories = ['brinkman_zaak'];
       for (var category of subjectCategories){
-        listOfsubjects = subjects[category];
-        for (var subject of listOfsubjects){
-            addSubjectRow(category, subject['term'], subject['identifier']);
+        listOfSubjects = subjects[category];
+        table_name = category.includes('brinkman')? 'brinkman':category
+        for (var subject of listOfSubjects){
+            addSubjectRow(table_name, 'kind', subject['term'], subject['identifier']);
         }
       }
     }

--- a/demosauruswebapp/demosaurus/static/js/subjects-tab.js
+++ b/demosauruswebapp/demosaurus/static/js/subjects-tab.js
@@ -119,8 +119,8 @@ function displayResults(resultList, category, subcategory) {
       term = value.label;
       color=getColorForPercentage(value.score);
       $('#annif-results-table > tbody').append(
-        $('<tr onclick="addSubjectRow(\''+category+'\',\''+subcategory+'\',\''+ term+'\',\''+ identifier+'\')" title="Selecteer term">')
-        .append($('<td >')
+        $('<tr>')
+        .append($('<td class="highlight" onclick="addSubjectRow(\''+category+'\',\''+subcategory+'\',\''+ term+'\',\''+ identifier+'\')" title="Selecteer term">')
                  .text(term)
                 )
         .append($('<td class="match_cell" style="background-color:'+color+'">').text(Math.round(value.score * 1000)/10))

--- a/demosauruswebapp/demosaurus/static/style.css
+++ b/demosauruswebapp/demosaurus/static/style.css
@@ -80,9 +80,10 @@ textarea {
 
 .zebra tr:nth-child(odd){background: hsla(46, 78%, 90%, 1);}
 .zebra tr:nth-child(even){background: hsla(46, 78%, 80%, 1);}
-.zebra tr:hover {
-  background: hsla(46, 78%, 70%, 1);
-}
+/*.zebra tr:hover {  background: hsla(46, 78%, 70%, 1);}
+*/
+
+.highlight:hover {background: hsla(46, 78%, 70%, 1);}
 
 /* Table with extra info author and publication on 'authorpage.html' and 'view.html' */
 .tbinfo td:first-child { font-weight: bold; white-space: nowrap; padding-right: 20px; width: 1em; }

--- a/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
@@ -20,6 +20,26 @@
 
 <div style="width:100%;float:left;">
 
+<div class='bottomcontent' id="contributors_content" style="display: block;">
+    <h2 id=thesaureer_title></h2>
+    <div id='thesaureer_content'></div>
+    <table id="candidate_list" class="fixed_header">
+      <thead>
+        <tr>
+            <th/>
+            <th>PPN</th>
+            <th>Naam</th>
+            <th>ISNI</th>
+            <th>Notitie</th>
+            <th>Leefjaren</th>
+            <th>Match</th>
+        </tr>
+      </thead>
+    </table>
+  </div>
+</div>
+
+    <!--
   <div class='bottomcontent' id="contributors_content" style="display: block;">
     <h2 id=thesaureer_title></h2>
     <div id='placeholder'></div>
@@ -30,6 +50,7 @@
     </table>
   </div>
 </div>
+-->
 
 <!-- thesaureerblock sub-scores tooltip table.-->
 <div class="divTable" id="thesMatchHover" style="display: none;">

--- a/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
@@ -23,7 +23,7 @@
 <div class='bottomcontent' id="contributors_content" style="display: block;">
     <h2 id=thesaureer_title></h2>
     <div id='thesaureer_content'></div>
-    <table id="candidate_list" class="fixed_header zebra">
+    <table id="candidate_list" class="fixed_header zebra" style.visibility = "hidden">
       <thead>
         <tr>
             <th/>
@@ -40,48 +40,3 @@
   </div>
 </div>
 
-    <!--
-  <div class='bottomcontent' id="contributors_content" style="display: block;">
-    <h2 id=thesaureer_title></h2>
-    <div id='placeholder'></div>
-    <table id="candidate_list" class="fixed_header">
-      <thead/>
-      <tbody class="zebra"/>
-      <tfoot/>
-    </table>
-  </div>
-</div>
--->
-
-<!-- thesaureerblock sub-scores tooltip table.-->
-<div class="divTable" id="thesMatchHover" style="display: none;">
-  <div class="divTableHeading">
-    <div class="divTableRow">
-      <div class="divTableHead"></div>
-      <div class="divTableHead">Score</div>
-      <div class="divTableHead">Confidence</div>
-    </div>
-  </div>
-  <div class="divTableBody">
-    <div class="divTableRow">
-      <div class="divTableCell" id="tttb13"><b>Naam</b></div>
-      <div class="divTableCell" id="tttb14">&nbsp;</div>
-      <div class="divTableCell" id="tttb15">&nbsp;</div>
-    </div>
-    <!--      <div class="divTableRow">-->
-    <!--        <div class="divTableCell" id="tttb1"><b>Rol</b></div>-->
-    <!--        <div class="divTableCell" id="tttb2">&nbsp;</div>-->
-    <!--        <div class="divTableCell" id="tttb3">&nbsp;</div>-->
-    <!--      </div>-->
-    <div class="divTableRow">
-      <div class="divTableCell" id="tttb4"><b>Genre</b></div>
-      <div class="divTableCell" id="tttb5">&nbsp;</div>
-      <div class="divTableCell" id="tttb6">&nbsp;</div>
-    </div>
-    <div class="divTableRow">
-      <div class="divTableCell" id="tttb7"><b>JvU</b></div>
-      <div class="divTableCell" id="tttb8">&nbsp;</div>
-      <div class="divTableCell" id="tttb9">&nbsp;</div>
-    </div>
-  </div>
-</div>

--- a/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
@@ -35,6 +35,7 @@
             <th>Match</th>
         </tr>
       </thead>
+        <tbody class="zebra"/>
     </table>
   </div>
 </div>

--- a/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/contributors-tab.html
@@ -23,7 +23,7 @@
 <div class='bottomcontent' id="contributors_content" style="display: block;">
     <h2 id=thesaureer_title></h2>
     <div id='thesaureer_content'></div>
-    <table id="candidate_list" class="fixed_header">
+    <table id="candidate_list" class="fixed_header zebra">
       <thead>
         <tr>
             <th/>

--- a/demosauruswebapp/demosaurus/templates/publication/general-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/general-tab.html
@@ -20,7 +20,7 @@
       </tr>
       <tr>
         <td>Jaar van uitgave</td>
-        <td id="publicationYear" contenteditable="true"> {{ publication['jaar_van_uitgave']}}</td>
+        <td id="publicationYear" contenteditable="true"> {{publication['jaar_van_uitgave']}}</td>
       </tr>
       <tr>
         <td>Uitgever</td>

--- a/demosauruswebapp/demosaurus/templates/publication/subjects-tab.html
+++ b/demosauruswebapp/demosaurus/templates/publication/subjects-tab.html
@@ -74,7 +74,7 @@
 
       <img id="annif-logo" src={{'/static/annif-RGB.svg'}} alt="annif-logo" width="130px">
       <span class="extra-info">
-        Annif is de tool die suggesties doet voor trefwoorden. De modellen zijn getraind op basis van GGC-metadata van kinderboeken.<br>
+        Annif is de tool die suggesties doet voor trefwoorden. De modellen zijn getraind op basis van GGC-metadata.<br>
         Suggesties worden gegenereerd op basis van de publicatietitel en samenvatting (tab <a href="#" onclick="openTab(event, 'general-tab')">Titelinformatie</a>).
       </span>
     </div>

--- a/demosauruswebapp/demosaurus/templates/publication/view.html
+++ b/demosauruswebapp/demosaurus/templates/publication/view.html
@@ -12,7 +12,7 @@
 
 <!-- The following script instantiates js variables holding genre info etc > still necessary? -->
   <script type=text/javascript>
-      var pilotMode = true;
+      var pilotMode = false;
 
     // initialize vars holding the role options and contributors
     console.log('Initializing variables')

--- a/demosauruswebapp/demosaurus/test/test_link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/test/test_link_thesaurus.py
@@ -1,0 +1,2 @@
+def test_candidates_with_features_query():
+    assert False

--- a/demosauruswebapp/demosaurus/test/test_link_thesaurus.py
+++ b/demosauruswebapp/demosaurus/test/test_link_thesaurus.py
@@ -1,2 +1,89 @@
+import demosauruswebapp.demosaurus as demosaurus
+from demosauruswebapp.demosaurus import link_thesaurus
+import pandas as pd
+from werkzeug.datastructures import MultiDict
+
+instance_path = '/home/sara/Metadata/Thesaureren/Demosaurus/demosauruswebapp/instance'
+# absolute path to dir where the instance (database, among other things) lives that you want to test against
+app = demosaurus.create_app(instance_path=instance_path)
+
+
 def test_candidates_with_features_query():
-    assert False
+    cand_q, params = link_thesaurus.candidate_query(author_name='aa')
+    q = link_thesaurus.candidates_with_features_query(candidates_query=cand_q)
+    df = run_query(q, params)
+    assert type(df) == pd.DataFrame
+
+
+def test_candidate_query():
+    print(app.instance_path)
+    cand_q, params = link_thesaurus.candidate_query(author_name='aa')
+    df = run_query(cand_q, params)
+    assert type(df) == pd.DataFrame
+
+
+def run_query(query, params={}):
+    with app.app_context() as context:
+        with link_thesaurus.get_db() as db:
+            return pd.read_sql_query(query, params=params, con=db)
+
+
+def test_similarity_features_query():
+    cand_q, params = link_thesaurus.candidate_query(author_name='aa')
+    features = ['CBK_genre', 'brinkman_vorm', 'brinkman_zaak', 'NUR_rubriek', 'NUGI_genre', 'jaar_van_uitgave']
+    q = link_thesaurus.similarity_features_query(features=features, candidates_query=cand_q)
+    df = run_query(q, params)
+    assert type(df) == pd.DataFrame
+    assert 'author_ppn' in df.dtypes.keys()
+    assert 'knownPublications' in df.dtypes.keys()
+    for feature in features:
+        assert feature in df.dtypes.keys()
+
+
+def test_obtain_candidates():
+    features = ['CBK_genre', 'brinkman_vorm', 'brinkman_zaak', 'NUR_rubriek', 'NUGI_genre', 'jaar_van_uitgave']
+    with app.app_context() as context:
+        candidates, similarity_data = link_thesaurus.obtain_candidates(author_name='aa', features=features)
+    for df in [candidates, similarity_data]:
+        assert type(df) == pd.DataFrame
+        assert 'author_ppn' in df.dtypes.keys()
+
+
+def test_wrap_publication_info():
+    request_args = MultiDict(
+        [('contributor_name', 'Fabio  @Stassi'), ('contributor_role', 'aut'), ('publication_title', 'De @laatste dans'),
+         ('publication_genres',
+          '{"CBK_genre":[],"NUR_rubriek":[{"rank":"1","identifier":"302"}],"NUGI_genre":[],"brinkman_vorm":[{"rank":"1","identifier":"075629410","term":"romans en novellen ; vertaald"}]}'),
+         ('publication_year', ' 2014'), ('extended_search', 'false'), ('_', '1643874874535')])
+    wrapped_publication, features_to_obtain = link_thesaurus.wrap_publication_info(request_args)
+    assert type(wrapped_publication) == pd.DataFrame
+    assert wrapped_publication['this_publication'].sum() == len(
+        wrapped_publication)  # every row should have a count of one
+    for i in wrapped_publication.index:
+        assert wrapped_publication.loc[[i]].isna().sum().sum() == (
+                    len(wrapped_publication.columns) - 2)  # two columns (the relevant value and the counter) should be NaN
+    assert "075629410" in wrapped_publication['brinkman_vorm'].values
+    assert "302" in wrapped_publication['NUR_rubriek'].values
+
+    # Assert features_to_obtain is a dict of dicts of list of strings
+    for feature_kind in ['nominal', 'ordinal', 'textual']:
+        assert feature_kind in features_to_obtain
+        assert type(features_to_obtain[feature_kind]) == dict
+        for feature, itemlist in features_to_obtain[feature_kind].items():
+            assert type(feature) == str
+            for item in itemlist:
+                assert type(item) == str
+
+
+def test_obtain_and_score_candidates():
+    author_name = 'Liesbeth  @Dillo'
+    request_args = MultiDict(
+        [('contributor_name', 'Jan @Janssen'), ('contributor_role', 'aut'), ('publication_title', 'De @laatste dans'),
+         ('publication_genres',
+          '{"CBK_genre":[],"NUR_rubriek":[{"rank":"1","identifier":"302"}],"NUGI_genre":[],"brinkman_vorm":[{"rank":"1","identifier":"075629410","term":"romans en novellen ; vertaald"}]}'),
+         ('publication_year', ' 2014'), ('extended_search', 'false'), ('_', '1643874874535')])
+    wrapped_publication, features_to_obtain = link_thesaurus.wrap_publication_info(request_args)
+    with app.app_context() as context:
+        scored_candidates = link_thesaurus.obtain_and_score_candidates(author_name, wrapped_publication, features_to_obtain)
+    assert type(scored_candidates) == pd.DataFrame
+

--- a/demosauruswebapp/performance_thesaureren.py
+++ b/demosauruswebapp/performance_thesaureren.py
@@ -4,6 +4,33 @@ import numpy as np
 #import matplotlib.pyplot as plt
 import pandas as pd
 import demosaurus
+import os.path
+
+import demosauruswebapp.demosaurus.link_thesaurus
+
+def f_name(name, outdir = 'NBD'):
+    return os.path.join(outdir, f'{name}.csv')
+
+def data_exists(name, outdir = 'NBD'):
+    return os.path.exists(f_name(name, outdir = outdir))
+
+def load_data(name, outdir = 'NBD'):
+    fname = f'{name}.csv'
+    df = pd.read_csv(os.path.join(outdir, fname))
+    return df
+
+def save_data(df, name, outdir = 'NBD', overwrite=False):
+    if not overwrite and data_exists(name, outdir = outdir):
+        print('Not overwriting', f_name(name, outdir=outdir))
+        pass
+    else:
+        df.to_csv(f_name(name, outdir=outdir), index=False)
+
+def query_to_df(query):
+    with app.app_context() as context:
+        with demosaurus.db.get_db() as con:
+            df = pd.read_sql_query(query, con=con)
+    return df
 
 app = demosaurus.create_app()
 
@@ -36,7 +63,57 @@ def score_candidates(row):
 
     return pd.Series([rank_correct,nCandidates, score_correct], index=['rank_correct','nCandidates','score_correct'])
 
-if __name__ == "__main__":
+
+def obtain_candidates(test_items=None, outdir='NBD', overwrite = False):
+    if test_items is None:
+        test_items = obtain_test_items(outdir=outdir)
+    names = test_items.name_normalized
+    query = "SELECT * FROM "
+
+    return
+
+def obtain_test_items(outdir='NBD', overwrite = False, mock = True):
+    t_name = 'test_items'+('_mock' if mock else '')
+    if data_exists(t_name):
+        test_items =  load_data(t_name,outdir=outdir)
+    else:
+        if mock:
+            query = """SELECT t1.publication_ppn, t1.rank, t1.role,  t2.author_ppn AS candidate_author_ppn, t2.author_ppn = t1.author_ppn AS target
+		FROM publication_contributors_test_NBD t1
+		LEFT JOIN 
+		(	
+SELECT DISTINCT author_ppn FROM publication_contributors_train_NBD LIMIT 9) AS t2
+UNION 
+SELECT t1.publication_ppn, t1.rank, t1.role, t1.author_ppn AS candidate_author_ppn, t1.author_ppn = t1.author_ppn AS target
+		FROM publication_contributors_test_NBD t1"""
+        else:
+            query = """SELECT t1.publication_ppn, t1.rank, t1.author_ppn, t1.name_normalized, t2.author_ppn AS candidate_author_ppn, t2.author_ppn = t1.author_ppn AS target
+            FROM publication_contributors_test_NBD t1
+            LEFT JOIN 
+            (	SELECT t3.* FROM author_name_options t3
+                JOIN publication_contributors_train_NBD t4 ON t3.author_ppn = t4.author_ppn) AS t2
+                ON t2.name_normalized = t1.name_normalized
+            GROUP BY t1.publication_ppn, t1.rank, t2.author_ppn"""
+        test_items = query_to_df(query)
+        save_data(test_items, t_name, outdir=outdir)
+    return test_items
+
+
+
+
+
+def obtain_similarity_data(outdir='NBD'):
+    if data_exists('author_aggregated'):
+        df = load_data('author_aggregated', outdir=outdir)
+    else:
+        query = "SELECT * FROM author_aggregated"
+        df = query_to_df(query)
+        save_data(df, 'author_aggregated', outdir=outdir)
+    return df
+#name: "{{contributor['title'] if contributor['title']}}{{' '.join([contributor['firstname'] or '',contributor['prefix'] or '','@' + contributor['familyname'] or ''])}}",
+
+def testset_query():
+
     testset_query = """
     SELECT t1.*, t2.titelvermelding, t2.jaar_van_uitgave,
     group_concat(DISTINCT t3.CBK_genre) AS CBK_genres,
@@ -50,6 +127,7 @@ if __name__ == "__main__":
     LIMIT 250
     """
 
+def performance_old():
     TESTSET_FILE = '../data/performance/thesaureren_testset.csv'
     RESULTS_FILE = '../data/performance/performance_thesaureren_testset.csv'
     CHUNK_SIZE = 50
@@ -59,16 +137,15 @@ if __name__ == "__main__":
     except:
         with app.app_context() as context:
             with demosaurus.db.get_db() as db:
-                testset = pd.read_sql_query(testset_query, con = db)
+                testset = pd.read_sql_query(testset_query, con=db)
             testset.to_csv(TESTSET_FILE, sep=';', index=False)
     try:
         results = pd.read_csv(RESULTS_FILE, sep=';')
     except:
-        results = pd.DataFrame({'publication_ppn':[]})
+        results = pd.DataFrame({'publication_ppn': []})
 
     testset = testset.loc[
         ~testset.publication_ppn.isin(results.publication_ppn)]  # only evaluate items that haven't been evaluated yet
-
 
     for start_i in range(0, len(testset), CHUNK_SIZE):
         index_slice = [j for j in range(start_i, min(len(testset), start_i + CHUNK_SIZE))]
@@ -76,3 +153,15 @@ if __name__ == "__main__":
         result['publication_ppn'] = testset.publication_ppn.iloc[index_slice]
         results = results.append(result)
         results.to_csv(RESULTS_FILE, sep=';', index=False)
+
+
+if __name__ == "__main__":
+
+    similarity_data = obtain_similarity_data()
+    test_items = obtain_test_items()
+    #candidates = obtain_candidates(test_items)
+
+
+
+
+

--- a/demosauruswebapp/performance_thesaureren.py
+++ b/demosauruswebapp/performance_thesaureren.py
@@ -1,12 +1,17 @@
 from importlib import reload
 import scipy
+
+import warnings
+warnings.simplefilter('ignore',FutureWarning)
 import numpy as np
 #import matplotlib.pyplot as plt
 import pandas as pd
+
+#import dataprocessing.views_and_indices as views
 import demosaurus
 import os.path
 
-import demosauruswebapp.demosaurus.link_thesaurus
+from dataprocessing.views import author_aggregated_query
 
 def f_name(name, outdir = 'NBD'):
     return os.path.join(outdir, f'{name}.csv')
@@ -34,35 +39,6 @@ def query_to_df(query):
 
 app = demosaurus.create_app()
 
-def score_candidates(row):
-    print(row.publication_ppn)
-    author_name=str(row['name'])
-    author_role = row.role
-    publication_title = row.titelvermelding
-    publication_genres={
-        'CBK_genre':(str(row.CBK_genres).split(',') if row.CBK_genres else []),
-        'brinkman':(str(row.Brinkman_vorm).split(',') if row.Brinkman_vorm else []) }
-    publication_year= row.jaar_van_uitgave
-
-    try:
-        with app.app_context() as context:
-            candidates = demosaurus.link_thesaurus.thesaureer_this(author_name,author_role, publication_title, publication_genres, publication_year)
-    except:
-        print('Failed to obtain candidates for', row)
-        candidates = pd.DataFrame()
-    nCandidates = len(candidates)
-    rank_correct = -1
-    score_correct = -1
-    if nCandidates>0:
-        candidates['rank'] = candidates['score'].rank(ascending=False)
-        try:
-            rank_correct = candidates.loc[candidates.author_ppn == row.author_ppn, 'rank'].iloc[0]
-            score_correct = candidates.loc[candidates.author_ppn == row.author_ppn, 'score'].iloc[0]
-        except:
-            print('True author ('+str(row.author_ppn)+') not in candidate list for publication', row.publication_ppn)
-
-    return pd.Series([rank_correct,nCandidates, score_correct], index=['rank_correct','nCandidates','score_correct'])
-
 
 def obtain_candidates(test_items=None, outdir='NBD', overwrite = False):
     if test_items is None:
@@ -72,20 +48,20 @@ def obtain_candidates(test_items=None, outdir='NBD', overwrite = False):
 
     return
 
-def obtain_test_items(outdir='NBD', overwrite = False, mock = True):
-    t_name = 'test_items'+('_mock' if mock else '')
+def obtain_test_items(outdir='NBD', overwrite = False, mock = 0):
+    t_name = 'test_items'+('_mock'+str(mock) if mock else '')
     if data_exists(t_name):
         test_items =  load_data(t_name,outdir=outdir)
     else:
         if mock:
-            query = """SELECT t1.publication_ppn, t1.rank, t1.role,  t2.author_ppn AS candidate_author_ppn, t2.author_ppn = t1.author_ppn AS target
-		FROM publication_contributors_test_NBD t1
-		LEFT JOIN 
-		(	
-SELECT DISTINCT author_ppn FROM publication_contributors_train_NBD LIMIT 9) AS t2
-UNION 
-SELECT t1.publication_ppn, t1.rank, t1.role, t1.author_ppn AS candidate_author_ppn, t1.author_ppn = t1.author_ppn AS target
-		FROM publication_contributors_test_NBD t1"""
+            query = """SELECT publication_ppn, rank, role, author_ppn FROM publication_contributors_test_NBD WHERE author_ppn IS NOT NULL"""
+            true_items = query_to_df(query)
+            test_items = pd.concat(9*[true_items], ignore_index = True)
+            test_items['candidate_ppn'] = true_items.author_ppn.sample(len(test_items), replace = True).values # sample 9 random authors from the test set
+            test_items['target'] = test_items.apply(lambda row: int(row.author_ppn == row.candidate_ppn), axis =1)
+            true_items['candidate_ppn'] = true_items['author_ppn']
+            true_items['target'] = 1
+            test_items = pd.concat([test_items,true_items], ignore_index = True) # add the true author to the candidates
         else:
             query = """SELECT t1.publication_ppn, t1.rank, t1.author_ppn, t1.name_normalized, t2.author_ppn AS candidate_author_ppn, t2.author_ppn = t1.author_ppn AS target
             FROM publication_contributors_test_NBD t1
@@ -94,11 +70,9 @@ SELECT t1.publication_ppn, t1.rank, t1.role, t1.author_ppn AS candidate_author_p
                 JOIN publication_contributors_train_NBD t4 ON t3.author_ppn = t4.author_ppn) AS t2
                 ON t2.name_normalized = t1.name_normalized
             GROUP BY t1.publication_ppn, t1.rank, t2.author_ppn"""
-        test_items = query_to_df(query)
+            test_items = query_to_df(query)
         save_data(test_items, t_name, outdir=outdir)
     return test_items
-
-
 
 
 
@@ -127,41 +101,127 @@ def testset_query():
     LIMIT 250
     """
 
-def performance_old():
-    TESTSET_FILE = '../data/performance/thesaureren_testset.csv'
-    RESULTS_FILE = '../data/performance/performance_thesaureren_testset.csv'
-    CHUNK_SIZE = 50
+def obtain_publication_data(outdir='NBD'):
+    if data_exists('publications_wrapped', outdir=outdir):
+        df = load_data('publications_wrapped', outdir=outdir)
+    else:
+        # Like views_and_indices aggregated_author_query with the following changes:
+        #q = dataprocessing.views_and_indices.author_aggregated_query(ignore=['role'])
+        q = author_aggregated_query(ignore=['role'])
+        q = q.replace('publication_contributors_train_NBD',
+                      'publication_contributors_test_NBD')  # use test data as selection criterion
+        q = q.replace('SELECT t0.publication_ppn, t0.author_ppn',
+                      'SELECT DISTINCT t0.publication_ppn')  # (aggregate on publication level rather than author level)
+        q = q.replace('t1.author_ppn',
+                      't1.publication_ppn')  # (aggregate on publication level rather than author level)
+        q = q.replace('AS knownPublications', 'AS this_publication')
+        q = q.replace('WHERE t0.author_ppn IS NOT NULL', '')
+        df = query_to_df(q)
+        save_data(df, 'publications_wrapped', outdir=outdir)
+    return df
 
-    try:
-        testset = pd.read_csv(TESTSET_FILE, sep=';')
-    except:
-        with app.app_context() as context:
-            with demosaurus.db.get_db() as db:
-                testset = pd.read_sql_query(testset_query, con=db)
-            testset.to_csv(TESTSET_FILE, sep=';', index=False)
-    try:
-        results = pd.read_csv(RESULTS_FILE, sep=';')
-    except:
-        results = pd.DataFrame({'publication_ppn': []})
+def score_itemset(test_item_set, wrapped_publication, similarity_data):
+    """
+    Compute performance for a set of test items with
+    """
+    #assert test_item_set.name
+    wrapped_publication = pd.concat([wrapped_publication,
+        pd.DataFrame.from_dict({'publication_ppn':[test_item_set.name],
+                    'term': [test_item_set.role.iloc[0]],
+                    'term_description': ['role'],
+                    'this_publication': [1]
+                  })])
+    scores = test_item_set.groupby('candidate_ppn').apply(
+        lambda author: \
+            pd.merge(wrapped_publication, # this merge raises a FutureWarning that I don't understand
+                     similarity_data.loc[similarity_data.author_ppn == author.name],
+                     how='outer') \
+            .fillna(0).groupby(['term_description'])\
+                .apply(demosaurus.link_thesaurus.score_feature) \
+                .groupby(['term_category'])
+                    .apply(lambda x:
+                        pd.Series([np.average(x.score, weights=x.confidence),
+                                   x.confidence.mean()] if sum(x.confidence)>0 else [0,0],
+                                index=['score', 'confidence']))
+               ).unstack()
+    scores.columns = [i[1] + '_' + i[0] for i in scores.columns.to_flat_index()]  # flatten column index
+    feature_list = ['genre', 'year', 'role']
+    score_items = [feature + '_score' for feature in feature_list]
+    weight_items = [feature + '_confidence' for feature in feature_list]
+    scores['score'] = scores.apply(
+        lambda row: np.average(row.loc[score_items], weights=row.loc[weight_items]) if sum(
+            row.loc[weight_items]) > 0 else 0, axis=1)
+    scores['support'] = scores.apply(
+        lambda row: np.mean(row.loc[weight_items]), axis=1)
+    return scores
 
-    testset = testset.loc[
-        ~testset.publication_ppn.isin(results.publication_ppn)]  # only evaluate items that haven't been evaluated yet
+def score_test_items(test_items, similarity_data, publication_data, filename, outdir='NBD', overwrite = True):
+    if data_exists(filename, outdir=outdir):
+        scores = load_data(filename, outdir=outdir)
+    else:
+        scores = test_items.merge(test_items.groupby(['publication_ppn', 'author_ppn']).apply(
+            lambda test_item_set: score_itemset(
+                test_item_set,
+                publication_data.loc[publication_data.publication_ppn == test_item_set.name[0]],
+                similarity_data)),
+            left_on=['publication_ppn', 'author_ppn', 'candidate_ppn'], right_index=True)
+        save_data(scores, filename, outdir=outdir)
+    return scores
 
-    for start_i in range(0, len(testset), CHUNK_SIZE):
-        index_slice = [j for j in range(start_i, min(len(testset), start_i + CHUNK_SIZE))]
-        result = testset.iloc[index_slice].apply(score_candidates, axis=1)
-        result['publication_ppn'] = testset.publication_ppn.iloc[index_slice]
-        results = results.append(result)
-        results.to_csv(RESULTS_FILE, sep=';', index=False)
+def compute_performance(scores):
+    scores['rank_score'] = scores.groupby(['publication_ppn', 'author_ppn'])['score'].rank(ascending=False)
+    scores['rank_genre'] = scores.groupby(['publication_ppn', 'author_ppn'])['genre_score'].rank(ascending=False)
+    scores['rank_role'] = scores.groupby(['publication_ppn', 'author_ppn'])['role_score'].rank(ascending=False)
+    scores['rank_year'] = scores.groupby(['publication_ppn', 'author_ppn'])['year_score'].rank(ascending=False)
 
+    target_scores_all = scores.loc[scores.target == 1]
+    no_info = len(target_scores_all.loc[target_scores_all.support == 0])
+    target_scores = target_scores_all.loc[target_scores_all.support > 0]
+
+    features = {'Overall': 'rank_score', 'Genre': 'rank_genre', 'Role': 'rank_role', 'Year': 'rank_year'}
+    recalls = pd.DataFrame({feat: {
+        f'recall@{i}': len(target_scores.loc[target_scores[feat_col] <= i]) / len(target_scores)
+            for i in range(1, 11)}
+            for feat, feat_col in features.items()})
+    precisions = {feat: {
+        f'precision@{i}': len(target_scores.loc[target_scores[feat_col] <= i]) / len(scores.loc[scores[feat_col] <= i])
+        for i in range(1, 11)}
+        for feat, feat_col in features.items()}
+
+    print(f"""Since the dataset is quite limited, also in terms of ambiguity for authors,
+    we chose to perform an analysis with synthetic data: for every (real) author attribution 
+    in the test set, we randomly sampled 9 other authors from the test set as artificial candidates 
+    to perform a ranking with. 
+    Note that we do not consider author names in the scoring procedure, only in the candidate selection step.
+
+    There are {no_info} cases ({round(100 * no_info / len(target_scores_all))}%) \
+    where no contextual information about the true author (earlier publications) was known. 
+    In those cases, it is impossible for the tool to correctly rank those authors, 
+    so we leave them out from the rest of the analysis. 
+    Of course, the same holds for the artificial candidates, 
+    so the actual (informed) ranked list consists of slightly over 8 candidates on average.
+
+    In {round(100 * recalls['Overall']['recall@1'])}% of the cases, the correct author is the top candidate in the ranking. 
+    In {round(100 * recalls['Overall']['recall@2'])}%, the correct author is amongst the top three. 
+
+    The dataset is quite homogeneous: the variety year of publishing is limited. 
+    This means that the authors are hard to distinguish based on this feature.
+    The role, on the other hand, is as distinguishing a feature as anytime, 
+    but is limited in general, because the majority of contributors are in fact Author.
+    It turns out that genre is the best distinguishing feature in this case, 
+    partly because the set contains both children's books and adult material. 
+    """)
+
+    return recalls, precisions
 
 if __name__ == "__main__":
-
+    mock=10
+    test_items = obtain_test_items(mock=mock).sort_values(by=['publication_ppn','author_ppn'])
     similarity_data = obtain_similarity_data()
-    test_items = obtain_test_items()
-    #candidates = obtain_candidates(test_items)
-
-
+    publication_data = obtain_publication_data()
+    scores = score_test_items(test_items, similarity_data, publication_data, filename='test_items_scored'+('_mock'+str(mock) if mock else ''))
+    recalls, precisions = compute_performance(scores)
+    #grouped_data = merge_and_group(test_items, similarity_data, publication_data)
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ joblib==0.17.0
 MarkupSafe
 nltk
 numpy
-pandas
+pandas>=1.2
 scipy
 python-dateutil==2.8.1
 pytz==2020.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ tqdm==4.54.1
 Werkzeug==2.0.1
 lxml
 unidecode
+rdflib


### PR DESCRIPTION
A lot more than just candidate selection was tackled in this branch. 

- Candidate retrieval is performed by search for the normalized name - to this end, all NTA spelling variations of author names are added (in normalized form) to the database
- In the front-end, the candidate table is generated directly using Datatables on a function call to obtain and score candidates
- Ordinal scores where implemented for year-score 
- The scoring mechanism was improved to obtain them more efficiently and to be able to evaluate the tool over a set of items. 
- A module is added to compute performance over a test set