### PR TITLE
Containerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+instance

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.7.12-slim as base
+MAINTAINER Sara Veldhoen <sara.veldhoen@kb.nl>
+
+RUN pip install --upgrade pip
+COPY requirements.txt /
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        make \
+        gcc \
+    && pip install -r requirements.txt \
+    && apt-get remove -y --purge make gcc build-essential \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+ENV HOME=/usr
+
+RUN groupadd -g 999 user && \
+    useradd -r -u 999 -g user user
+
+RUN mkdir /usr/app && chown user:user /usr/app
+WORKDIR /usr/app
+
+
+
+COPY --chown=user:user demosauruswebapp demosauruswebapp/
+
+USER 999
+EXPOSE 3345
+ENV GUNICORN_CMD_ARGS="--name demosaurus -w 4 --bind 0.0.0.0:5000 --preload"
+CMD ["gunicorn", "demosauruswebapp:create_app()"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ Flask>=2
 Flask-JSGlue
 numpy
 pandas>=1.2
-scipy==1.7.1
+scipy>=1.7.1
 unidecode
+gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas>=1.2
 scipy>=1.7.1
 unidecode
 gunicorn
+requests


### PR DESCRIPTION
Added Dockerfile for building image
Plus .dockerignore for instance folder (where the database lives)

From the repo, run `docker build --tag demosaurus .` to build the image. The application will be served within the docker on port 5000, using gunicorn (for safety). 

To start the container, run
```
docker run 	--detach \
 			--publish 3345:5000 \
 			--restart always \
 			--name demosaurus-live \
 			--mount type=bind,source="$PWD/instance",destination=/usr/app/instance,readonly \
 			demosaurus:latest
```
and it will be published on port 3345.
The instance folder is copied from the repo, so make sure that is where the database lives (or change `source=...` in the above).